### PR TITLE
fix: adjust stroke width for text rendering and improve contour detection in image processing

### DIFF
--- a/translator/src/manga_translator/drawing/horizontal.py
+++ b/translator/src/manga_translator/drawing/horizontal.py
@@ -119,7 +119,7 @@ class HorizontalDrawer(Drawer):
                 str(text),
                 fill=(255, 255, 255, 255),
                 font=font,
-                stroke_width=color.outline_size + 1,
+                stroke_width=color.outline_size,
                 stroke_fill=(255, 255, 255, 255),
             )
 

--- a/translator/src/manga_translator/pipelines/image_to_image.py
+++ b/translator/src/manga_translator/pipelines/image_to_image.py
@@ -190,11 +190,10 @@ class ImageToImagePipeline(Pipeline):
             x1, y1, x2, y2 = section.draw_bbox
 
             cleaned = section.source[y1:y2, x1:x2]
-            # Replace masked regions with white
-            a = cv2.bitwise_and(cleaned, cleaned, mask=cv2.bitwise_not(drawn_mask))
-            b = cv2.bitwise_and(drawn, drawn, mask=drawn_mask)
 
-            cv2.add(a, b, dst=section.source[y1:y2, x1:x2])
+            alpha = drawn_mask.astype(np.float32) / 255
+            alpha = alpha[..., None] # from (h,w) to (h,w,1)
+            section.source[y1:y2, x1:x2] = np.clip(drawn * alpha + cleaned * (1.0 - alpha), 0, 255).astype(np.uint8)
 
     @perf_async
     async def __call__(self, batch: list[np.ndarray]) -> list[np.ndarray]:

--- a/translator/src/manga_translator/utils.py
+++ b/translator/src/manga_translator/utils.py
@@ -536,8 +536,8 @@ def compute_draw_bbox(section: np.ndarray) -> Vector4i:
 
     p1x = np.maximum(0,p1x - padding) 
     p1y = np.maximum(0,p1y - padding) 
-    p2x = np.maximum(0,p2x - padding) 
-    p2y = np.maximum(0,p2y - padding) 
+    p2x = np.maximum(0,(p2x - padding) + 1) 
+    p2y = np.maximum(0,(p2y - padding) + 1) 
 
     return np.array([p1x, p1y, p2x, p2y], dtype=np.int32)
 

--- a/translator/src/manga_translator/utils.py
+++ b/translator/src/manga_translator/utils.py
@@ -490,13 +490,33 @@ def ensure_gray(img: np.ndarray) -> np.ndarray:
 
 def compute_draw_bbox(section: np.ndarray) -> Vector4i:
     grey = ensure_gray(section)
-
+    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (7, 7))
+    
     height, width = grey.shape[:2]
 
+    
     ret, thresh = cv2.threshold(grey, 200, 255, 0)
 
+
+    mostlyWhite = np.mean(thresh > 127) > 0.5
+
+    # if an image has a lot of white the actual bubble is probably black so we would want to invert it because morphology will cleanup white areas
+    if mostlyWhite:
+        thresh = 255 - thresh
+
+    
+    morphed = cv2.morphologyEx(thresh,cv2.MORPH_CLOSE,kernel,iterations=3)
+    morphed = cv2.dilate(morphed,kernel)
+
+    padding = 4
+    padded = np.zeros((height + (padding * 2),width + (padding * 2)),dtype=morphed.dtype)
+
+    start = padding
+    # pad and invert since bubble is probably black and cv2.findContours needs it white
+    padded[start:start + height,start:start + width] = 255 - morphed
+
     contours, hierarchy = cv2.findContours(
-        thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE
+        padded, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
     )
 
     if len(contours) == 0:
@@ -509,12 +529,15 @@ def compute_draw_bbox(section: np.ndarray) -> Vector4i:
 
     polygon = np.array([largest_contour], dtype=np.int32)
 
-    # cv2.imshow("foo",cv2.fillPoly(section.copy(),largest_contour,(255,0,0,255)))
-    # cv2.waitKey(0)
     rect = lir.lir(polygon)
 
     p1x, p1y = lir.pt1(rect)
     p2x, p2y = lir.pt2(rect)
+
+    p1x = np.maximum(0,p1x - padding) 
+    p1y = np.maximum(0,p1y - padding) 
+    p2x = np.maximum(0,p2x - padding) 
+    p2y = np.maximum(0,p2y - padding) 
 
     return np.array([p1x, p1y, p2x, p2y], dtype=np.int32)
 


### PR DESCRIPTION
closes #60

This pull request introduces several improvements to the manga translation pipeline, focusing on more accurate text bubble detection and compositing, as well as a minor adjustment to text drawing. The main changes enhance the robustness of bounding box computation for text regions and improve the alpha blending process when compositing drawn sections back onto the source image.

**Image processing and compositing improvements:**

* Improved the compositing of drawn sections in `composite_drawn_sections` by replacing the previous bitwise masking approach with proper alpha blending, ensuring smoother and more accurate overlays.

**Text bubble detection and bounding box calculation:**

* Enhanced the `compute_draw_bbox` function to more reliably detect text bubble regions:
  - Added morphological operations (morphological closing and dilation) to clean up thresholded images.
  - Dynamically inverts the thresholded image if the region is mostly white, improving detection of black-on-white bubbles.
  - Applies padding and inverts the morphed image before contour detection to ensure correct region extraction.
  - Adjusts the bounding box coordinates to account for padding, ensuring accurate region localization.

**Text drawing adjustment:**

* Slightly reduced the outline width used when drawing text by changing `stroke_width` from `color.outline_size + 1` to `color.outline_size`, likely to improve text appearance. 