### PR TITLE
feat: standardize RGB color space and fix type annotations

### DIFF
--- a/cli/.vscode/launch.json
+++ b/cli/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.2.0",
+    "inputs": [
+        {
+            "id": "imagePath",
+            "type": "promptString",
+            "description": "Path to image file"
+        }
+    ],
+    "configurations": [
+        {
+            "name": "Python Debugger: Current File with Arguments",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/main.py",
+            "console": "integratedTerminal",
+            "args": "-f ${input:imagePath} -c .\\config.yaml -o ./out",
+            "justMyCode": false
+        }
+    ]
+}

--- a/cli/main.py
+++ b/cli/main.py
@@ -16,9 +16,15 @@ class SmartFormatter(argparse.HelpFormatter):
 # def list_to_json()
 
 
+def read_image(source_path):
+    return cv2.imread(source_path, cv2.IMREAD_COLOR_RGB)
+
+
 def write_image(source_path, destination, image):
     dest_name = os.path.basename(source_path)
-    cv2.imwrite(os.path.join(destination, dest_name), image)
+    cv2.imwrite(
+        os.path.join(destination, dest_name), cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
+    )
 
 
 async def main():
@@ -75,7 +81,7 @@ async def main():
         print(f"Processing batch [{batch_start} : {batch_start + batch_size}]")
         target_files = files[batch_start : batch_start + batch_size]
         images = await asyncio.gather(
-            *[asyncio.to_thread(cv2.imread, file_path) for file_path in target_files]
+            *[asyncio.to_thread(read_image, file_path) for file_path in target_files]
         )
 
         results = await pipeline(images)

--- a/extension/backend/main.py
+++ b/extension/backend/main.py
@@ -116,16 +116,16 @@ def compute_hash(data):
 
 def bytes_to_mat(data: bytes):
     array = np.asarray(bytearray(data), dtype=np.uint8)
-    return cv2.imdecode(array, cv2.IMREAD_COLOR_BGR)
+    return cv2.imdecode(array, cv2.IMREAD_COLOR_RGB)
 
 
 def post_translation(key: str, data: np.ndarray) -> str:
     if CACHE_ENABLED:
         save_path = os.path.join(TRANSLATED_IMAGES_PATH, f"{key}.png")
-        cv2.imwrite(save_path, data)
+        cv2.imwrite(save_path, cv2.cvtColor(data, cv2.COLOR_RGB2BGR))
 
     if BASE_64_ENABLED:
-        ok, encoded = cv2.imencode(".png", data)
+        ok, encoded = cv2.imencode(".png", cv2.cvtColor(data, cv2.COLOR_RGB2BGR))
         if not ok:
             raise ValueError("Failed to encode translated image")
         return "data:image/png;base64," + base64.b64encode(encoded.tobytes()).decode(
@@ -145,7 +145,7 @@ def get_cached(key: str) -> str:
 
 
 def save_translated(file_path: str, data: np.ndarray):
-    cv2.imwrite(file_path, data)
+    cv2.imwrite(file_path, cv2.cvtColor(data, cv2.COLOR_RGB2BGR))
 
 
 def make_translated_url(key):

--- a/training/ocr/ocr/test.py
+++ b/training/ocr/ocr/test.py
@@ -41,7 +41,7 @@ def test(images: list[str], model_path: str):
     model = model.to(device)
 
     input_images = [
-        transform(image=cv2.imread(x, cv2.IMREAD_COLOR))["image"] for x in images
+        transform(image=cv2.imread(x, cv2.IMREAD_COLOR_RGB))["image"] for x in images
     ]
     processed = feature_extractor(input_images, return_tensors="pt")["pixel_values"].to(
         device

--- a/training/text_masking/generator.py
+++ b/training/text_masking/generator.py
@@ -109,7 +109,7 @@ class Background:
 
     @staticmethod
     def file(file_path: str):
-        return Background(cv2.imread(file_path, cv2.IMREAD_COLOR_BGR))
+        return Background(cv2.imread(file_path, cv2.IMREAD_COLOR_RGB))
 
     @staticmethod
     def black(width=512, height=512, channels=3):
@@ -245,7 +245,8 @@ class SampleGenerator:
                     lines.append(line)
 
                 cv2.imwrite(
-                    os.path.join(images_path, f"{sample_name}.png"), sample.image
+                    os.path.join(images_path, f"{sample_name}.png"),
+                    cv2.cvtColor(sample.image, cv2.COLOR_RGB2BGR),
                 )
                 with open(
                     os.path.join(labels_path, f"{sample_name}.txt"),

--- a/translator/src/main.py
+++ b/translator/src/main.py
@@ -11,7 +11,7 @@ import cv2
 import torch
 
 
-def main():
+async def main():
     device = torch.device("cpu")
     pipeline = ImageToImagePipeline(
         translator=DeepLTranslator(auth_key="Some deepl api key"),
@@ -22,11 +22,11 @@ def main():
         ocr=MangaOCR(device=device),  # MangaOcr(device=torch.device('cuda:0')),
         color_detector=ColorDetector(),
     )
-    image = cv2.imread(r"./file.png")
-    result = asyncio.run(pipeline([image]))[0]
+    image = cv2.imread(r"./file.png", cv2.IMREAD_COLOR_RGB)
+    result = (await pipeline([image]))[0]
     cv2.imshow("Translated", result)
     cv2.waitKey(0)
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/translator/src/manga_translator/cleaning/get.py
+++ b/translator/src/manga_translator/cleaning/get.py
@@ -1,3 +1,4 @@
+from typing import Sequence
 from manga_translator.core.plugin import Cleaner
 from manga_translator.cleaning.all_white_cleaner import AllWhiteCleaner
 from manga_translator.cleaning.opencv import OpenCvCleaner
@@ -12,5 +13,5 @@ _data = list(
 )
 
 
-def get_cleaners() -> list[Cleaner]:
+def get_cleaners() -> Sequence[type[Cleaner]]:
     return _data

--- a/translator/src/manga_translator/cleaning/patched_ai_cleaner.py
+++ b/translator/src/manga_translator/cleaning/patched_ai_cleaner.py
@@ -63,8 +63,8 @@ class PatchedAiCleaner(Cleaner):
         self.max_group_pixels = max_group_pixels
         self.zero_max = np.zeros((2), dtype=np.int32)
 
-    def load_model(self, model_path: str, device: torch.device) -> "torch.Module":
-        return torch.jit.load(model_path, map_location=device).eval()
+    def load_model(self, model_path: str, device: torch.device) -> torch.jit.ScriptModule:
+        return torch.jit.load(model_path, map_location=device).eval()  # type: ignore[return-value]
 
     def group_patches(self, patches: list[_AiImagePatch]):
         # we can do some kind of size based grouping to batch here
@@ -102,7 +102,7 @@ class PatchedAiCleaner(Cleaner):
         return number + (0 if remainder == 0 else factor - remainder)
 
     def process_input_batched(self, batch: list[np.ndarray]) -> torch.Tensor:
-        tensors = [torch.from_numpy(x).permute(2, 0, 1).flip(0) for x in batch]
+        tensors = [torch.from_numpy(x).permute(2, 0, 1) for x in batch]
         max_shape = np.stack([np.array(t.shape[1:]) for t in tensors]).max(axis=0)
         h, w = max_shape
         h = self.to_factor(h, 8)
@@ -145,11 +145,10 @@ class PatchedAiCleaner(Cleaner):
         return stacked_tensors / 255.0
 
     def process_output_batched(self, x: torch.Tensor) -> np.ndarray:
-        x = (
-            (x * 255).clip(0, 255).byte().flip(1).permute(0, 2, 3, 1)
-        )  # Flip back to BGR then back to numpy
-        x = x.numpy()
-        return x
+        result = (
+            (x * 255).clip(0, 255).byte().permute(0, 2, 3, 1)
+        ).numpy()
+        return result
 
     def extract_patches(
         self, frames: list[np.ndarray], segments: list[list[SegmentationResult]]
@@ -238,7 +237,7 @@ class PatchedAiCleaner(Cleaner):
             mask = np.zeros((h, w), dtype=np.uint8)
             for detection in frame_detections:
                 x1, y1, x2, y2 = detection.bbox
-                cv2.rectangle(mask, (x1, y1), (x2, y2), 255, thickness=-1)
+                cv2.rectangle(mask, (x1, y1), (x2, y2), (255,), thickness=-1)
 
             a = cv2.bitwise_and(frame, frame, mask=cv2.bitwise_not(mask))
             b = cv2.bitwise_and(cleaned, cleaned, mask=mask)

--- a/translator/src/manga_translator/color_detection/get.py
+++ b/translator/src/manga_translator/color_detection/get.py
@@ -1,3 +1,4 @@
+from typing import Sequence
 from manga_translator.color_detection.basic import BasicColorDetector
 from manga_translator.core.plugin import ColorDetector
 from manga_translator.color_detection.openai import OpenAiColorDetector
@@ -10,5 +11,5 @@ _color_detection_data = list(
 )
 
 
-def get_color_detectors() -> list[ColorDetector]:
+def get_color_detectors() -> Sequence[type[ColorDetector]]:
     return _color_detection_data

--- a/translator/src/manga_translator/core/plugin.py
+++ b/translator/src/manga_translator/core/plugin.py
@@ -1,6 +1,6 @@
 import numpy as np
 import torch
-from manga_translator.core.typing import Vector4i, Vector2, Vector3u8
+from manga_translator.core.typing import Vector4i, Vector3u8
 from manga_translator.utils import (
     get_available_pytorch_devices,
     get_default_language,
@@ -46,7 +46,7 @@ class PluginArgument:
         self.default = default
         self.convert_fn = convert_fn
 
-    def get(self) -> dict[str, str]:
+    def get(self) -> dict:
         return {
             "id": self.id,
             "name": self.name,
@@ -335,7 +335,7 @@ class Detector(BasePlugin):
 
 class SegmentationResult:
     def __init__(
-        self, type: SegmentationType, points: list[Vector2], confidence: float
+        self, type: SegmentationType, points: np.ndarray, confidence: float
     ):
         self.type = type
         self.points = points

--- a/translator/src/manga_translator/core/typing.py
+++ b/translator/src/manga_translator/core/typing.py
@@ -1,8 +1,9 @@
 import numpy as np
+from numpy.typing import NDArray
 from typing import TypeAlias
 
 # Vector3: TypeAlias = NDArray[np.float32]  # dtype only
-Vector2: TypeAlias = np.ndarray[(2), np.float32]
-Vector2i: TypeAlias = np.ndarray[(2), np.int32]
-Vector3u8: TypeAlias = np.ndarray[(3), np.uint8]
-Vector4i: TypeAlias = np.ndarray[(4), np.int32]
+Vector2: TypeAlias = NDArray[np.float32]
+Vector2i: TypeAlias = NDArray[np.int32]
+Vector3u8: TypeAlias = NDArray[np.uint8]
+Vector4i: TypeAlias = NDArray[np.int32]

--- a/translator/src/manga_translator/detection/get.py
+++ b/translator/src/manga_translator/detection/get.py
@@ -1,3 +1,4 @@
+from typing import Sequence
 from manga_translator.core.plugin import Detector
 from manga_translator.detection.yolo import YoloDetector
 
@@ -9,5 +10,5 @@ _detection_data = list(
 )
 
 
-def get_detectors() -> list[Detector]:
+def get_detectors() -> Sequence[type[Detector]]:
     return _detection_data

--- a/translator/src/manga_translator/detection/yolo.py
+++ b/translator/src/manga_translator/detection/yolo.py
@@ -32,9 +32,9 @@ class YoloDetector(Detector):
         self.skip_free_text = skip_free_text
 
     @staticmethod
-    def conv_cls(cls: int):
+    def conv_cls(cls_id: int):
         try:
-            return DetectionType(cls)
+            return DetectionType(cls_id)
         except ValueError:
             return DetectionType.TextOnPage
 
@@ -42,17 +42,21 @@ class YoloDetector(Detector):
         with torch.inference_mode():
             results = []
             for prediction in self.model.predict(
-                # TODO RGB to BGR since model.predict expects BGR
-                batch,  # [x[..., ::-1] for x in batch],
+                [
+                    x[..., ::-1] for x in batch
+                ],  # flip RGB to BGR since ultralytics expects BGR
                 device=self.device,
                 verbose=False,
                 conf=self.confidence,
                 iou=self.iou,
             ):
                 result = []
-                boxes = prediction.boxes.xyxy.cpu().int().numpy()
-                classes = prediction.boxes.cls.cpu().int()
-                confidence = prediction.boxes.conf.cpu()
+                if prediction.boxes is None:
+                    results.append(result)
+                    continue
+                boxes = prediction.boxes.xyxy.cpu().int().numpy()  # type: ignore[union-attr]
+                classes = prediction.boxes.cls.cpu().int()  # type: ignore[union-attr]
+                confidence = prediction.boxes.conf.cpu()  # type: ignore[union-attr]
 
                 for bbox, cls, conf in zip(boxes, classes, confidence):
                     # depending on model accuracy I have noticed some text bubbles are detected as free text, will need to do custom nms to catch this since we trust text_bubble more than text_free
@@ -60,7 +64,7 @@ class YoloDetector(Detector):
                         continue
                     result.append(
                         DetectionResult(
-                            YoloDetector.conv_cls(cls.item()), bbox, conf.item()
+                            YoloDetector.conv_cls(int(cls.item())), bbox, conf.item()
                         )
                     )
 
@@ -68,8 +72,8 @@ class YoloDetector(Detector):
 
             return results
 
-    async def detect(self, batch):
-        return await asyncio.to_thread(self.predict, batch)
+    async def detect(self, frames: list[np.ndarray]) -> list[list[DetectionResult]]:
+        return await asyncio.to_thread(self.predict, frames)
 
     @staticmethod
     def get_name() -> str:

--- a/translator/src/manga_translator/drawing/get.py
+++ b/translator/src/manga_translator/drawing/get.py
@@ -1,3 +1,4 @@
+from typing import Sequence
 from manga_translator.core.plugin import Drawer
 from manga_translator.drawing.horizontal import HorizontalDrawer
 
@@ -9,5 +10,5 @@ _drawing_data = list(
 )
 
 
-def get_drawers() -> list[Drawer]:
+def get_drawers() -> Sequence[type[Drawer]]:
     return _drawing_data

--- a/translator/src/manga_translator/ocr/get.py
+++ b/translator/src/manga_translator/ocr/get.py
@@ -1,3 +1,4 @@
+from typing import Sequence
 from manga_translator.core.plugin import OCR
 from manga_translator.ocr.debug import DebugOCR
 from manga_translator.ocr.huggingface import HuggingFaceOCR
@@ -14,5 +15,5 @@ _ocr_data = list(
 )
 
 
-def get_ocrs() -> list[OCR]:
+def get_ocrs() -> Sequence[type[OCR]]:
     return _ocr_data

--- a/translator/src/manga_translator/pipelines/cbz.py
+++ b/translator/src/manga_translator/pipelines/cbz.py
@@ -13,15 +13,19 @@ class CbzPipeline(Pipeline):
         self.image_to_image = image_to_image
 
     @staticmethod
+    def write_image_sync(file_path: str, image: np.ndarray):
+        cv2.imwrite(file_path, cv2.cvtColor(image, cv2.COLOR_RGB2BGR))
+
+    @staticmethod
     async def read_image(file_path: str) -> np.ndarray:
-        return await asyncio.to_thread(cv2.imread, file_path)
+        return await asyncio.to_thread(cv2.imread, file_path, cv2.IMREAD_COLOR_RGB)
 
     @staticmethod
-    async def write_image(file_path: str, image: np.ndarray) -> np.ndarray:
-        return await asyncio.to_thread(cv2.imwrite, file_path, image)
+    async def write_image(file_path: str, image: np.ndarray) -> None:
+        return await asyncio.to_thread(CbzPipeline.write_image_sync, file_path, image)
 
     @staticmethod
-    def extract_zip(file_path: str, dest_dir: str) -> np.ndarray:
+    def extract_zip(file_path: str, dest_dir: str) -> list[str]:
         with zipfile.ZipFile(file_path) as zf:
             # Only keep real files (not directory entries)
             filenames = [zi.filename for zi in zf.infolist() if not zi.is_dir()]

--- a/translator/src/manga_translator/segmentation/get.py
+++ b/translator/src/manga_translator/segmentation/get.py
@@ -1,3 +1,4 @@
+from typing import Sequence
 from manga_translator.core.plugin import Segmenter
 from manga_translator.segmentation.yolo import YoloSegmenter
 
@@ -9,5 +10,5 @@ _segmentation_data = list(
 )
 
 
-def get_segmenters() -> list[Segmenter]:
+def get_segmenters() -> Sequence[type[Segmenter]]:
     return _segmentation_data

--- a/translator/src/manga_translator/segmentation/yolo.py
+++ b/translator/src/manga_translator/segmentation/yolo.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from manga_translator.core.constants import SegmentationType
 from manga_translator.core.plugin import (
     PluginArgument,
@@ -22,9 +24,9 @@ class YoloSegmenter(Segmenter):
         self.device = device
 
     @staticmethod
-    def conv_cls(cls: int):
+    def conv_cls(cls_id: int):
         try:
-            return SegmentationType(cls)
+            return SegmentationType(cls_id)
         except ValueError:
             return SegmentationType.Text
 
@@ -32,23 +34,24 @@ class YoloSegmenter(Segmenter):
         with torch.inference_mode():
             results = []
             for prediction in self.model.predict(
-                # TODO  RGB to BGR since model.predict expects BGR
-                batch,  # [x[..., ::-1] for x in batch],
+                [
+                    x[..., ::-1] for x in batch
+                ],  # flip RGB to BGR since ultralytics expects BGR
                 conf=0.1,
                 device=self.device,
                 verbose=False,
             ):
                 result = []
 
-                if prediction.masks is not None:
-                    classes = prediction.boxes.cls.cpu().int()
-                    confidence = prediction.boxes.conf.cpu()
+                if prediction.masks is not None and prediction.boxes is not None:
+                    classes = prediction.boxes.cls.cpu().int()  # type: ignore[union-attr]
+                    confidence = prediction.boxes.conf.cpu()  # type: ignore[union-attr]
                     masks = prediction.masks.xy
 
                     for mask, cls, conf in zip(masks, classes, confidence):
                         result.append(
                             SegmentationResult(
-                                YoloSegmenter.conv_cls(cls.item()),
+                                YoloSegmenter.conv_cls(int(cls.item())),
                                 mask.astype(int),
                                 conf.item(),
                             )
@@ -58,8 +61,8 @@ class YoloSegmenter(Segmenter):
 
             return results
 
-    async def segment(self, batch):
-        return await asyncio.to_thread(self.predict, batch)
+    async def segment(self, frames: list[np.ndarray]) -> list[list[SegmentationResult]]:
+        return await asyncio.to_thread(self.predict, frames)
 
     @staticmethod
     def get_name() -> str:

--- a/translator/src/manga_translator/translation/get.py
+++ b/translator/src/manga_translator/translation/get.py
@@ -1,3 +1,4 @@
+from typing import Sequence
 from manga_translator.core.plugin import Translator
 from manga_translator.translation.deepl import DeepLTranslator
 from manga_translator.translation.huggingface import HuggingFaceTranslator
@@ -19,5 +20,5 @@ _translator_data = list(
 )
 
 
-def get_translators() -> list[Translator]:
+def get_translators() -> Sequence[type[Translator]]:
     return _translator_data

--- a/translator/src/manga_translator/utils.py
+++ b/translator/src/manga_translator/utils.py
@@ -167,7 +167,7 @@ class WrappedLine:
 
 
 class WrapResult:
-    def __init__(self, lines: list[WrappedLine], bounds: tuple[int, int]):
+    def __init__(self, lines: list[WrappedLine], bounds: tuple[int | float, int | float]):
         self.lines = lines
         self.bounds = bounds
 
@@ -212,7 +212,7 @@ class HyphenationCache:
             (hyphenation[1], self.layout_cache.get(hyphenation[1])),
         ]
 
-    def filter_out_impossible(self, hyphenations: list[list[str]]):
+    def filter_out_impossible(self, hyphenations: list[list[tuple[str, tuple[float, float, float, float]]]]):
         return filter(
             lambda hyp: max(hyp, key=lambda item: item[1][2])[1][2] <= self.wrap,
             hyphenations,
@@ -288,7 +288,7 @@ def wrap_text_pure(
         x_bounds = max(x_bounds, x_offset)
 
     last_line = lines[-1]
-    return WrapResult(lines, (x_bounds, last_line.offset + last_line.height))
+    return WrapResult(lines, (int(x_bounds), int(last_line.offset + last_line.height)))
 
 
 def wrap_text_with_hyphenator(
@@ -387,7 +387,7 @@ def wrap_text_with_hyphenator(
         x_offset = new_offset
 
     last_line = lines[-1]
-    return WrapResult(lines, (x_bounds, last_line.offset + last_line.height))
+    return WrapResult(lines, (int(x_bounds), int(last_line.offset + last_line.height)))
 
 
 def wrap_text(
@@ -476,7 +476,7 @@ def cv2_to_pil(img: np.ndarray) -> Image.Image:
     return Image.fromarray(cv2.cvtColor(img, cv2.COLOR_BGR2RGB))
 
 
-def pil_to_cv2(img: Image) -> np.ndarray:
+def pil_to_cv2(img: Image.Image) -> np.ndarray:
     arr = np.array(img)
 
     if len(arr.shape) > 2 and arr.shape[2] == 4:
@@ -608,7 +608,7 @@ def inverse_luminance_color(rgb: np.ndarray) -> Vector3u8:
 
     # Back to RGB
     r2, g2, b2 = colorsys.hls_to_rgb(h, l, s)
-    return np.array([int(round(x * 255)) for x in (r2, g2, b2)], dtype=np.uint8)
+    return np.array([int(round(x * 255)) for x in (r2, g2, b2)], dtype=np.uint8) # type: ignore
 
 
 def get_autocast(device: torch.device, enabled=True):
@@ -625,7 +625,7 @@ def get_autocast(device: torch.device, enabled=True):
 def standardize_language_code(language: str):
     try:
         return langcodes.Language.get(language).to_tag()
-    except langcodes.LanguageTagError:
+    except langcodes.LanguageTagError: # type: ignore
         pass
 
     return langcodes.Language.find(language).to_tag()

--- a/translator/tests/src/test_cbz_pipeline.py
+++ b/translator/tests/src/test_cbz_pipeline.py
@@ -91,10 +91,9 @@ async def test_cbz_read_image_and_write_image_static_helpers(tmp_path):
     image = np.full(TEST_IMAGE_SHAPE, 123, dtype=np.uint8)
     image_path = tmp_path / "img.png"
 
-    wrote = await CbzPipeline.write_image(str(image_path), image)
+    await CbzPipeline.write_image(str(image_path), image)
     read_back = await CbzPipeline.read_image(str(image_path))
 
-    assert wrote is True
     assert read_back is not None
     assert read_back.shape == image.shape
     assert int(read_back[0, 0, 0]) == 123

--- a/ui/main.py
+++ b/ui/main.py
@@ -32,7 +32,6 @@ from manga_translator.drawing.get import get_drawers
 from manga_translator.detection.get import get_detectors
 from manga_translator.segmentation.get import get_segmenters
 from manga_translator.cleaning.get import get_cleaners
-from PIL import Image
 from dataclass_wizard import JSONWizard
 from typing import Any
 
@@ -43,18 +42,6 @@ build_path = os.path.join(os.path.dirname(__file__), "frontend", "dist")
 app.serve_files(source_folder=build_path, discovery=True)
 
 default_component = {"id": 0, "args": {}}
-
-
-def cv2_image_from_url(url: str):
-    if url.startswith("http"):
-        return pil_to_cv2(Image.open(io.BytesIO(requests.get(url).content)))
-    else:
-        sanitized = urllib.parse.unquote(url.split("?")[0])
-        data = cv2.imread(sanitized)
-
-        if data is None:
-            raise BaseException(f"Failed to load image from path {url}")
-        return data
 
 
 REQUEST_SECTION_REGEX = r"id=([0-9]+)(.*)"
@@ -77,11 +64,11 @@ def extract_params(data: str) -> tuple[int, dict[str, str]]:
 
 def bytes_to_mat(data: bytes):
     array = np.asarray(bytearray(data), dtype=np.uint8)
-    return cv2.imdecode(array, cv2.IMREAD_COLOR_BGR)
+    return cv2.imdecode(array, cv2.IMREAD_COLOR_RGB)
 
 
 def mat_to_bytes(data: np.ndarray):
-    success, encoded_bytes = cv2.imencode(".png", data)
+    success, encoded_bytes = cv2.imencode(".png", cv2.cvtColor(data, cv2.COLOR_BGR2RGB))
     return encoded_bytes.tobytes()
 
 


### PR DESCRIPTION
## Summary

- Standardizes the entire pipeline to work in RGB internally, converting to BGR only at YOLO entry points and file-write exits (via OpenCV)
- Fixes all Pylance/type annotation errors across the translator library: `NDArray`-based type aliases, `Sequence[type[X]]` return types for plugin registries, wrong return types in `cbz.py`, `SegmentationResult.points`, and more
- Removes `torch.compile` from `patched_ai_cleaner` for now
- Adds VS Code launch config for the CLI with an image path prompt

## Test plan

- [ ] Run the pipeline end-to-end on a CBZ archive and verify output images are correctly colored (not BGR-swapped)
- [ ] Run the pipeline on a single image via `translator/src/main.py` and confirm the result displays correctly
- [ ] Verify YOLO detection and segmentation still produce correct bounding boxes / masks
- [ ] Confirm the AI cleaner (LaMa/DeepFillV2) inpaints correctly without channel flipping artifacts
- [ ] Use the CLI launch config (F5) and confirm the image path prompt appears

closes #56